### PR TITLE
Fixed wrong clone error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See **building** below for building the gem.
 Use `vagrant plugin` to install the gem in your Vagrant environment:
 
 ```bash
-$ vagrant plugin install vagrant-git.gem
+$ vagrant plugin install vagrant-git
 ```
 
 ## Configuration
@@ -40,12 +40,12 @@ The following properties are optional (but not yet supported):
 
 * **branch**: Which branch to check out / pull
 * **clone_in_host**: *boolean*: true to execute git commands in the host, false to execute them in the guest. NOT YET SUPPORTED for false.
-* **pull_on_load**: whether to do a fetch & pull when starting up the VM
+* **sync_on_load**: whether to do a fetch & pull when starting up the VM
 * **set_upstream**: a different remote URL to set the upstream origin to after cloning the repository
 
 ## Building
 
 ```bash
 $ bundle install
-$ gem build vagrant-sparseimage.gemspec
+$ gem build vagrant-git.gemspec
 ```

--- a/lib/vagrant-git/action.rb
+++ b/lib/vagrant-git/action.rb
@@ -37,8 +37,8 @@ module VagrantPlugins
                   errors[rc.path].push(err)
                   @vm.ui.error(err)
                 end
-			  elsif !p.success?
-				  err = "Failed to clone #{rc.target} into #{rc.path}"
+              elsif !p.success?
+                err = "Failed to clone #{rc.target} into #{rc.path}"
                 errors[rc.path].push(err)
                 @vm.ui.error(err)
               end

--- a/lib/vagrant-git/action.rb
+++ b/lib/vagrant-git/action.rb
@@ -37,8 +37,8 @@ module VagrantPlugins
                   errors[rc.path].push(err)
                   @vm.ui.error(err)
                 end
-              else !p.success?
-                err = "Failed to clone #{rc.target} into #{rc.path}"
+			  elsif !p.success?
+				  err = "Failed to clone #{rc.target} into #{rc.path}"
                 errors[rc.path].push(err)
                 @vm.ui.error(err)
               end

--- a/lib/vagrant-git/version.rb
+++ b/lib/vagrant-git/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module VagrantGit
-    VERSION = "0.1.5"
+    VERSION = "0.1.6"
   end
 end


### PR DESCRIPTION
After cloning successfully, vagrant-git was printing error message about clone failure.

    Cloning into 'folder/project'...
    remote: Counting objects: 3, done.
    remote: Total 3 (delta 0), reused 0 (delta 0)
    Receiving objects: 100% (3/3), done.
    Checking connectivity... done.
    ==> default: Failed to clone git@some.address.com:web/project.git into folder/project
    ==> default: WARNING: Encountered errors when cloning repos.
    ==> default: -- folder/project --
    ==> default: Failed to clone git@some.address.com:web/project.git into folder/project
    ==> default: If these were due to transient network issues, try again with:
    ==> default:    vagrant halt
    ==> default:    vagrant up

The problem was a missing `elsif` in the clone action code.