### PR TITLE
Changed fork to spawn for windows compatibility

### DIFF
--- a/lib/vagrant-git/git.rb
+++ b/lib/vagrant-git/git.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class << self
         # Run the command, wait for exit and return the Process object.
         def run(cmd)
-          pid = Process.fork { exec(cmd) }
+          pid = spawn(cmd)
           Process.waitpid(pid)
           return $?
         end


### PR DESCRIPTION
We love using this plugin, but found it would not work on windows because Process.fork is not implemented on windows. This has been tested on both windows and OSX and is working well though. Would love to be able to install it with "vagrant plugin install vagrant-git"
